### PR TITLE
Remove deprecated write(stop=) arguments

### DIFF
--- a/barbudor_tmp75.py
+++ b/barbudor_tmp75.py
@@ -118,7 +118,7 @@ class TMP75:
         buf = bytearray(3)
         buf[0] = reg
         with self.i2c_device as i2c:
-            i2c.write(buf, end=1, stop=False)
+            i2c.write(buf, end=1)
             i2c.readinto(buf, start=1)
         value = (buf[1] << 8) | (buf[2])
         return value
@@ -132,7 +132,7 @@ class TMP75:
         buf = bytearray(2)
         buf[0] = reg
         with self.i2c_device as i2c:
-            i2c.write(buf, end=1, stop=False)
+            i2c.write(buf, end=1)
             i2c.readinto(buf, start=1)
         value = buf[2]
         return value


### PR DESCRIPTION
The final `stop` argument in the write function seems to be deprecated and throws errors in CircuitPython. 

Discussed here: 
https://github.com/adafruit/Adafruit_CircuitPython_BusDevice/pull/54
https://github.com/adafruit/Adafruit_CircuitPython_BusDevice/pull/55

Tested on CircuitPython 9.2.4 on Adafruit QT Py ESP32S2